### PR TITLE
unique auto completion hits

### DIFF
--- a/src/Attribute/LevenshteinIndexLookup.php
+++ b/src/Attribute/LevenshteinIndexLookup.php
@@ -16,7 +16,7 @@
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Oliver Willmes <info@oliverwillmes.de>
- * @copyright  2012-2022 The MetaModels team.
+ * @copyright  2012-2023 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_levenshtein/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */

--- a/src/Attribute/LevenshteinIndexLookup.php
+++ b/src/Attribute/LevenshteinIndexLookup.php
@@ -15,6 +15,7 @@
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Oliver Willmes <info@oliverwillmes.de>
  * @copyright  2012-2022 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_levenshtein/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -183,6 +184,7 @@ class LevenshteinIndexLookup
                 FROM tl_metamodel_levensthein_index AS lx
                 LEFT JOIN tl_metamodel_levensthein AS l ON (l.id=lx.pid)
                 WHERE %1$s
+                GROUP BY lx.word
                 ORDER BY FIELD(lx.attribute,%2$s), lx.word',
             \implode(' AND ', $procedure),
             \implode(',', \array_fill(0, \count($attributeIds), '?'))

--- a/src/Controller/Frontend/AjaxSearch.php
+++ b/src/Controller/Frontend/AjaxSearch.php
@@ -89,7 +89,11 @@ class AjaxSearch
         }
 
         /** @var AttributeLevenshtein $attribute */
-        $suggestions = $attribute->getSuggestions($search);
+        $suggestions = array_values(
+            array_unique(
+                $attribute->getSuggestions($search)
+            )
+        );
 
         return new JsonResponse(
             array_map(

--- a/src/Controller/Frontend/AjaxSearch.php
+++ b/src/Controller/Frontend/AjaxSearch.php
@@ -90,11 +90,7 @@ class AjaxSearch
         }
 
         /** @var AttributeLevenshtein $attribute */
-        $suggestions = array_values(
-            array_unique(
-                $attribute->getSuggestions($search)
-            )
-        );
+        $suggestions = $attribute->getSuggestions($search);
 
         return new JsonResponse(
             array_map(

--- a/src/Controller/Frontend/AjaxSearch.php
+++ b/src/Controller/Frontend/AjaxSearch.php
@@ -14,7 +14,8 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2012-2022 The MetaModels team.
+ * @author     Oliver Willmes <info@oliverwillmes.de>
+ * @copyright  2012-2023 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_levensthein/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */


### PR DESCRIPTION
## Description

If more than one attribute is selected for auto-completion, hits are output multiple times.
This changes makes hits unique.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
